### PR TITLE
change example-jdbc addition/subtraction steps to be configured properly

### DIFF
--- a/example-scripts/bash-scripts/full-harvest-examples/example-jdbc/diff-additions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/example-jdbc/diff-additions.config.xml
@@ -47,7 +47,7 @@
 <%  a synonym for "RDF/XML".					  																	  %>
 <%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
 -->
-	<Param name="dumptofile">data/vivo-additions.rdf.xml</Param>
+  <Param name="dumptofile">xmlrdf=data/vivo-additions.rdf.xml</Param>
 	    <!--OUTPUT : for more information please see the given config file -->
 <!-- 
 <%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>

--- a/example-scripts/bash-scripts/full-harvest-examples/example-jdbc/diff-subtractions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/example-jdbc/diff-subtractions.config.xml
@@ -47,8 +47,8 @@
 <%  a synonym for "RDF/XML".					  																	  %>
 <%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
 -->
-	<Param name="dumptofile">data/vivo-subtractions.rdf.xml</Param>
-	
+  <Param name="dumptofile">xmlrdf=data/vivo-subtractions.rdf.xml</Param>
+
 	    <!--OUTPUT : for more information please see the given config file -->
 <!-- 
 <%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>


### PR DESCRIPTION
the configuration for the addition/subtraction stages of the example-jdbc script were incorrect and stopped a vanilla harvest running on the demodb.   